### PR TITLE
Enclose printed strings in single quotes in 5.11

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -4091,7 +4091,7 @@ function is called \verb"raw_input".
 >>> text = input()
 What are you waiting for?
 >>> text
-What are you waiting for?
+'What are you waiting for?'
 \end{verbatim}
 %
 Before getting input from the user, it is a good idea to print a
@@ -4104,7 +4104,7 @@ prompt as an argument:
 What...is your name?
 Arthur, King of the Britons!
 >>> name
-Arthur, King of the Britons!
+'Arthur, King of the Britons!'
 \end{verbatim}
 %
 The sequence \verb"\n" at the end of the prompt represents a {\bf


### PR DESCRIPTION
In Section 5.11 _Keyboard input_, since the values of _text_ and _name_ variables (both strings) are printed inside the Python interpreter, enclosing single quotes are missing in the output.