### PR TITLE
Remove an unnecessary print function call in 3.10

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -2540,7 +2540,7 @@ The value {\tt None} is not the same as the string \verb"'None'".
 It is a special value that has its own type:
 
 \begin{verbatim}
->>> print(type(None))
+>>> type(None)
 <class 'NoneType'>
 \end{verbatim}
 %


### PR DESCRIPTION
In 3.10 _Fruitful functions and void functions_, the _print_ function call is not needed in order to display the type of None inside the Python interpreter. Moreover, it is confusing at this point.