### PR TITLE
Add print function calls in 6.1 and 6.8

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -4578,7 +4578,7 @@ the absolute value of 0.
 \index{special value!None}
 
 \begin{verbatim}
->>> absolute_value(0)
+>>> print(absolute_value(0))
 None
 \end{verbatim}
 %
@@ -5122,10 +5122,10 @@ an error message and returns {\tt None} to indicate that something
 went wrong:
 
 \begin{verbatim}
->>> factorial('fred')
+>>> print(factorial('fred'))
 Factorial is only defined for integers.
 None
->>> factorial(-2)
+>>> print(factorial(-2))
 Factorial is not defined for negative integers.
 None
 \end{verbatim}


### PR DESCRIPTION
In 6.1 _Return values_ and 6.8 _Checking types_, _print_ function calls are needed to display None, returned by _absolute_value_ and _factorial_ functions, inside the Python interpreter.