### PR TITLE
Correct __lt__ method description in 18.3

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -14169,7 +14169,7 @@ the built-in operators by providing a method named
 \index{type!programmer-defined}
 
 \verb"__lt__" takes two parameters, {\tt self} and {\tt other},
-and {\tt True} if {\tt self} is strictly less than {\tt other}.
+and returns {\tt True} if {\tt self} is strictly less than {\tt other}.
 \index{override}
 \index{operator overloading}
 


### PR DESCRIPTION
In 18.3 _Comparing cards_, _returns_ is missing in `__lt__` method description.