### PR TITLE
Make the chemical formula example truly syntactically incorrect

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -1083,14 +1083,14 @@ govern the structure of statements.
 For example, in mathematics the statement
 $3 + 3 = 6$ has correct syntax, but
 $3 + = 3 \$ 6$ does not.  In chemistry
-$H_2O$ is a syntactically correct formula, but $_2Zz$ is not.
+$H_2O$ is a syntactically correct formula, but $Zz^2$ is not.
 \index{syntax}
 
 Syntax rules come in two flavors, pertaining to {\bf tokens} and
 structure.  Tokens are the basic elements of the language, such as
 words, numbers, and chemical elements.  One of the problems with
 $3 += 3 \$ 6$ is that \( \$ \) is not a legal token in mathematics
-(at least as far as I know).  Similarly, $_2Zz$ is not legal because
+(at least as far as I know).  Similarly, $Zz^2$ is not legal because
 there is no element with the abbreviation $Zz$.
 \index{token}
 \index{structure}
@@ -1098,8 +1098,8 @@ there is no element with the abbreviation $Zz$.
 The second type of syntax rule pertains to the way tokens are
 combined.  The equation $3 += 3$ is illegal because even though $+$
 and $=$ are legal tokens, you can't have one right after the other.
-Similarly, in a chemical formula the subscript comes after the element
-name, not before.
+Similarly, in a chemical formula the number of atoms is indicated
+using a subscript, not a superscript.
 
 This is @ well-structured Engli\$h
 sentence with invalid t*kens in it.  This sentence all valid tokens


### PR DESCRIPTION
Subscript before an element can be used to indicate its atomic number, which makes it syntactically legal.