### PR TITLE
new preamble/body demarcation string

### DIFF
--- a/code/analyze_book1.py
+++ b/code/analyze_book1.py
@@ -40,7 +40,7 @@ def skip_gutenberg_header(fp):
     fp: open file object
     """
     for line in fp:
-        if line.startswith('*END*THE SMALL PRINT!'):
+        if line.startswith('*** START OF TH'):
             break
 
 


### PR DESCRIPTION
As defined, "skip_gutenberg_header" would run through to the end of the file on many inputs (including the example of Emma!), leaving the ultimate output of the script empty.