### PR TITLE
Adding a comma that can make a difference

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -2028,7 +2028,7 @@ of $\pi$, accurate to about 15 digits.
 
 If you know
 trigonometry, you can check the previous result by comparing it to
-the square root of two divided by two:
+the square root of two, divided by two:
 \index{sqrt function}
 \index{function!sqrt}
 


### PR DESCRIPTION
This book is useful for people who don't know math, so it might be not obvious. If they read "the square root of two divided by two", it could be "the square root of (two divided by two)". This is a common trap on too many math test I've read. If you add the comma, you can read "(the square root of two), divided by two". Whitout the comma, you could make life harder for people frustrated with maths. Let's make it easier!