### PR TITLE
Add 'module object' index item

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -2651,7 +2651,7 @@ a module object.
 
 \item[module object:] A value created by an {\tt import} statement
 that provides access to the values defined in a module.
-\index{module}
+\index{module object}
 
 \item[dot notation:]  The syntax for calling a function in another
 module by specifying the module name followed by a dot (period) and


### PR DESCRIPTION
You have two 'module' index items but there is no 'module object' index item. One of the repeated items corresponds to the missing item.