### PR TITLE
Remove unnecessary colon

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -7402,7 +7402,7 @@ used to be 123, is now 5.
 
 Figure~\ref{fig.liststate} shows 
 the state diagram for {\tt
-cheeses}, {\tt numbers} and {\tt empty}:
+cheeses}, {\tt numbers} and {\tt empty}.
 \index{state diagram}
 \index{diagram!state}
 


### PR DESCRIPTION
In the code, the figure is after the colon. In the pdf, the figure is elsewhere.