### PR TITLE
 do_twice(print, 'spam')  change to  do_twice(print_twice, 'spam')

### DIFF
--- a/code/do_four.py
+++ b/code/do_four.py
@@ -41,7 +41,7 @@ def do_four(func, arg):
     do_twice(func, arg)
 
 
-do_twice(print, 'spam')
+do_twice(print_twice, 'spam')
 print('')
 
 do_four(print, 'spam')


### PR DESCRIPTION
The 3.14 Exercises:
4. Use the modified version of do_twice to call print_twice twice, passing 'spam' as an argument.
so  
do_twice(print, 'spam')  
should be change to  
do_twice(print_twice, 'spam')