### PR TITLE
Adding a note for more clarity

### DIFF
--- a/code/find_duplicates.py
+++ b/code/find_duplicates.py
@@ -38,6 +38,8 @@ def compute_checksum(filename):
 
     filename: string
     """
+    # Note: installing md5sha1sum is required
+
     cmd = 'md5sum ' + filename
     return pipe(cmd)
 


### PR DESCRIPTION
If md5sha1sum is not installed the following error will be thrown:

/bin/sh: md5sum: command not found
Traceback (most recent call last):
  File "test.py", line 118, in <module>
    d = compute_checksums(dirname='.', suffix='.py')
  File "test.py", line 77, in compute_checksums
    res, stat = compute_checksum(name)
  File "test.py", line 37, in compute_checksum
    return pipe(cmd)
  File "test.py", line 62, in pipe
    assert stat is None
AssertionError

The solution is to install it on the operating system